### PR TITLE
Added Comfort Features, ADB and File type checking

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -28,7 +28,7 @@ namespace ReplayUpdator
             if (selection.StartsWith("y")) PullReplays();
 
 
-            recursivefoldercheck(AppDomain.CurrentDomain.BaseDirectory);
+            recursiveFolderCheck(AppDomain.CurrentDomain.BaseDirectory);
             if (!Directory.Exists(oldReplaysDirectory)) {
                 Console.Error.WriteLine("Replays directory \"{0}\" not found. Please put your replays in this directory!", oldReplaysDirectory);
                 Console.ReadLine();
@@ -57,7 +57,7 @@ namespace ReplayUpdator
             adb("pull /sdcard/Android/data/com.beatgames.beatsaber/files/replays \"" + AppDomain.CurrentDomain.BaseDirectory.Substring(0, AppDomain.CurrentDomain.BaseDirectory.Length - 1) + "\"");
         }
 
-        private Boolean adb(String Argument)
+        private bool adb(String Argument)
         {
             ArrayList ADBPaths = new ArrayList();
             // Add all paths to ADB (with file extension) here
@@ -106,12 +106,12 @@ namespace ReplayUpdator
             return false;
         }
 
-        private void recursivefoldercheck(String folder)
+        private void recursiveFolderCheck(String folder)
         {
             // Move all files that end with .txt in the programs folder into the replays folder
             foreach (String CurrentFolder in Directory.GetDirectories(folder))
             {
-                recursivefoldercheck(CurrentFolder);
+                recursiveFolderCheck(CurrentFolder);
                 String FolderName = new DirectoryInfo(CurrentFolder).Name;
                 if (!FolderName.EndsWith(oldReplaysDirectory))
                 {
@@ -138,7 +138,7 @@ namespace ReplayUpdator
             }
         }
 
-        private Boolean updateReplay(string fileName, int CurrentFile) {
+        private bool updateReplay(string fileName, int CurrentFile) {
             // Check if the file is a replay
             if(!fileName.EndsWith(".txt"))
             {
@@ -147,7 +147,7 @@ namespace ReplayUpdator
                     Console.WriteLine("File " + CurrentFile + "/" + Directory.GetFiles(oldReplaysDirectory).Length + " (" + Path.GetFileNameWithoutExtension(fileName) + ") is a new Replay. Skipping.");
                 } else
                 {
-                    Console.WriteLine("File " + CurrentFile + "/" + Directory.GetFiles(oldReplaysDirectory).Length + " (" + Path.GetFileNameWithoutExtension(fileName) + ") is no old Replay. Skipping.");
+                    Console.WriteLine("File " + CurrentFile + "/" + Directory.GetFiles(oldReplaysDirectory).Length + " (" + Path.GetFileNameWithoutExtension(fileName) + ") isn't an old Replay. Skipping.");
                 }
                 return false;
             }

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Collections;
+using System.Diagnostics;
 
 namespace ReplayUpdator
 {
@@ -20,23 +22,135 @@ namespace ReplayUpdator
             Console.WriteLine("Updating replays . . .");
 
             // Check to see if the replays directory exists
-            if(!Directory.Exists(oldReplaysDirectory)) {
+
+            Console.WriteLine("Do you want to use adb to pull old replays? (y/n)");
+            String selection = Console.ReadLine();
+            if (selection.StartsWith("y")) PullReplays();
+
+
+            recursivefoldercheck(AppDomain.CurrentDomain.BaseDirectory);
+            if (!Directory.Exists(oldReplaysDirectory)) {
                 Console.Error.WriteLine("Replays directory \"{0}\" not found. Please put your replays in this directory!", oldReplaysDirectory);
+                Console.ReadLine();
                 return;
             }
 
             string[] oldReplays = Directory.GetFiles(oldReplaysDirectory);
             for(int i = 0; i < oldReplays.Length; i++) {
-                updateReplay(oldReplays[i]);
 
-                // Print a message to show progress
-                Console.WriteLine("Updated replay {0}/{1} ({2})", i + 1, oldReplays.Length, Path.GetFileNameWithoutExtension(oldReplays[i]));
+                // Print a message to show progress after updating the replay
+                if(updateReplay(oldReplays[i], i + 1))
+                {
+                    Console.WriteLine("Updated replay {0}/{1} ({2})", i + 1, oldReplays.Length, Path.GetFileNameWithoutExtension(oldReplays[i]));
+                }
             }
 
             Console.WriteLine("All replays converted!");
+            Console.ReadLine();
         }
 
-        private void updateReplay(string fileName) {
+        private void PullReplays()
+        {
+            // Console.WriteLine("Pulling Replays");
+
+            // Pull all replays
+            adb("pull /sdcard/Android/data/com.beatgames.beatsaber/files/replays \"" + AppDomain.CurrentDomain.BaseDirectory.Substring(0, AppDomain.CurrentDomain.BaseDirectory.Length - 1) + "\"");
+        }
+
+        private Boolean adb(String Argument)
+        {
+            ArrayList ADBPaths = new ArrayList();
+            // Add all paths to ADB (with file extension) here
+            ADBPaths.Add("adb.exe");
+            ADBPaths.Add("User\\Android\\platform-tools_r29.0.4-windows\\platform-tools\\adb.exe");
+            ADBPaths.Add("User\\AppData\\Roaming\\SideQuest\\platform-tools\\adb.exe");
+
+            // Get user env variable for Windows
+            String User = System.Environment.GetEnvironmentVariable("USERPROFILE"); //This May not work on Ubuntu and MacOS. Please check that.
+
+            foreach (String ADB in ADBPaths)
+            {
+                ProcessStartInfo s = new ProcessStartInfo();
+                s.CreateNoWindow = false;
+                s.UseShellExecute = false;
+                s.FileName = ADB.Replace("User", User);
+                s.WindowStyle = ProcessWindowStyle.Minimized;
+                s.Arguments = Argument;
+                s.RedirectStandardOutput = false;
+                // To check if a device is found set redirectstandartoutput to true
+                try
+                {
+                    // Start Process
+                    using (Process exeProcess = Process.Start(s))
+                    {
+                        //String IPS = exeProcess.StandardOutput.ReadToEnd();
+                        exeProcess.WaitForExit();
+                        /*
+                        if (IPS.Contains("no devices/emulators found"))
+                        {
+                            Console.WriteLine("Couldn't find your Quest. Check following:\n- Your Quest is connected, Developer Mode enabled and USB Debugging enabled.");
+                            return false;
+                        }
+                        */
+
+                        return true;
+                    }
+                }
+                catch
+                {
+                    continue;
+                }
+            }
+            // Nothing worked
+            Console.WriteLine("Couldn't find ADB.");
+            return false;
+        }
+
+        private void recursivefoldercheck(String folder)
+        {
+            // Move all files that end with .txt in the programs folder into the replays folder
+            foreach (String CurrentFolder in Directory.GetDirectories(folder))
+            {
+                recursivefoldercheck(CurrentFolder);
+                String FolderName = new DirectoryInfo(CurrentFolder).Name;
+                if (!FolderName.EndsWith(oldReplaysDirectory))
+                {
+                    foreach (String file in Directory.GetFiles(CurrentFolder))
+                    {
+                        if (file.EndsWith(".txt"))
+                        {
+                            File.Move(file, oldReplaysDirectory + "\\" + Path.GetFileName(file));
+                            Console.WriteLine("Moved old replay to right directory (" + Path.GetFileNameWithoutExtension(file) + ")");
+                        }
+                    }
+                }
+            }
+            if(folder == AppDomain.CurrentDomain.BaseDirectory)
+            {
+                foreach (String file in Directory.GetFiles(folder))
+                {
+                    if (file.EndsWith(".txt"))
+                    {
+                        File.Move(file, oldReplaysDirectory + "\\" + Path.GetFileName(file));
+                        Console.WriteLine("Moved old replay to right directory (" + Path.GetFileNameWithoutExtension(file) + ")");
+                    }
+                }
+            }
+        }
+
+        private Boolean updateReplay(string fileName, int CurrentFile) {
+            // Check if the file is a replay
+            if(!fileName.EndsWith(".txt"))
+            {
+                if(fileName.EndsWith("." + replayFileExtension))
+                {
+                    Console.WriteLine("File " + CurrentFile + "/" + Directory.GetFiles(oldReplaysDirectory).Length + " (" + Path.GetFileNameWithoutExtension(fileName) + ") is a new Replay. Skipping.");
+                } else
+                {
+                    Console.WriteLine("File " + CurrentFile + "/" + Directory.GetFiles(oldReplaysDirectory).Length + " (" + Path.GetFileNameWithoutExtension(fileName) + ") is no old Replay. Skipping.");
+                }
+                return false;
+            }
             // Read the contents of the replay file as text
             string replayContents = File.ReadAllText(fileName);
 
@@ -47,7 +161,7 @@ namespace ReplayUpdator
                 updatedReplay = Replay.loadOldReplay(replayContents);
             }   catch(Exception ex) {
                 Console.Error.WriteLine("An error occured while processing replay {0}: {1}", fileName, ex.Message);
-                return;
+                return false;
             }
 
             // Save the loaded replay using the binary format
@@ -55,6 +169,7 @@ namespace ReplayUpdator
             FileStream saveFile = File.Open(resultDirectory + "/" + nameWithoutExtension + "." + replayFileExtension, FileMode.Create);
             updatedReplay.saveWithNewFormat(new BinaryWriter(saveFile));
             saveFile.Close();
+            return true;
         }
 
         private static void Main(string[] args)


### PR DESCRIPTION
No actual Replay converting Code changed. All files in the programs directory that end with .txt (old replay extension) get moved to the convert directory. Added ADB pulling (Code totally not copied from [BMBF Manager](https://github.com/ComputerElite/BM/blob/7d0939d42d7b682b1f40023c9865b26305a00a3e/C%23/MainWindow.xaml.cs#L362)). When starting the convert the actual file extension gets checked